### PR TITLE
add white-space: pre to span css

### DIFF
--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -5,7 +5,7 @@ span {
     white-space: pre;
 }
 mark {
-    display: inline-block;
+    display: inline;
     position: relative;
     padding: 0 !important;
     color: inherit;

--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -2,7 +2,7 @@
 /* Now, the span is displayed right from the annotated text */
 /* Display the tag below the annotated text (centered and having the same width) */
 span {
-    white-space: pre;
+    white-space: pre-wrap;
 }
 mark {
     display: inline;

--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -1,6 +1,9 @@
 /* Structure: <mark>Annotated text <span>TAG</span></mark> */
 /* Now, the span is displayed right from the annotated text */
 /* Display the tag below the annotated text (centered and having the same width) */
+span {
+	white-space: pre	
+}
 mark {
     display: inline-block;
     position: relative;

--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -2,7 +2,7 @@
 /* Now, the span is displayed right from the annotated text */
 /* Display the tag below the annotated text (centered and having the same width) */
 span {
-	white-space: pre	
+	white-space: pre;
 }
 mark {
     display: inline-block;

--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -2,7 +2,7 @@
 /* Now, the span is displayed right from the annotated text */
 /* Display the tag below the annotated text (centered and having the same width) */
 span {
-	white-space: pre;
+    white-space: pre;
 }
 mark {
     display: inline-block;


### PR DESCRIPTION
A hasty attempt to address issue #8 -- add 
```
span {
    white-space: pre;
}
```
to style.css, and remove `inline-block` from the `mark` element.

<img width="560" alt="Screenshot 2024-05-02 at 11 58 14 AM" src="https://github.com/kevin91nl/text-highlighter/assets/4378846/17b16d89-833a-4de4-af1f-572704019993">
