### PR TITLE
Adjacent spans

### DIFF
--- a/text_highlighter/frontend/src/TextHighlighter.tsx
+++ b/text_highlighter/frontend/src/TextHighlighter.tsx
@@ -103,7 +103,7 @@ class MyComponent extends StreamlitComponentBase<BaseState> {
       let otherAnnotation = null;
       for (const annotation2 of annotations) {
         if (annotation1.start === annotation2.start && annotation1.end === annotation2.end) continue;
-        if ((annotation2.start <= annotation1.start && annotation2.end >= annotation1.start) || (annotation2.start <= annotation1.end && annotation2.end >= annotation1.end)) {
+        if ((annotation2.start <= annotation1.start && annotation2.end > annotation1.start) || (annotation2.start < annotation1.end && annotation2.end >= annotation1.end)) {
           isOverlapping = true;
           otherAnnotation = annotation2;
           break;

--- a/text_highlighter/frontend/src/style.css
+++ b/text_highlighter/frontend/src/style.css
@@ -10,6 +10,7 @@ mark {
     padding: 0 !important;
     color: inherit;
     line-height: 1 !important;
+    border-radius: 5px;
 }
 
 mark span {
@@ -23,6 +24,7 @@ mark span {
     line-height: 6px !important;
     width: 100%;
     text-align: center;
+    border-radius: 5px;
 }
 
 .label-pill {


### PR DESCRIPTION
Addresses [this issue](https://github.com/kevin91nl/text-highlighter/issues/15)

- Permit perfectly adjacent spans
- added rounding to the span highlights (this allows you to see the break between two perfectly adjacent spans)

Here is an example of what it looks like
<img width="748" alt="Screenshot 2024-11-11 at 9 35 50 AM" src="https://github.com/user-attachments/assets/e21e3773-91b8-4b93-ae7d-236a6482f970">
